### PR TITLE
feat: TGW中継プロキシ構成を追加する #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - サービス側: サービスVPC 1つ + 中継VPC 2つ
 - 拠点側: 拠点VPC 2つ（CIDR重複）
 - 拠点 -> 中継: Site-to-Site VPN（中継VGW、拠点CGW）
-- 中継 -> サービス: PrivateLink（NLB + Endpoint Service + Interface Endpoint）
+- 中継 -> サービス: TGW（メイン経路）+ PrivateLink（併用検証）
 
 ## ネットワーク構成
 
@@ -19,17 +19,23 @@
 - 固定Endpoint IP:
   - 中継A: `10.0.10.4`
   - 中継B: `10.0.10.36`
+- 固定中継Proxy IP:
+  - 中継A: `10.0.10.7`
+  - 中継B: `10.0.10.39`
 
 ## 構築対象
 
-- Amazon Linux 2023 + `t4g.nano` + `gp3 10GB` のEC2（サービス/拠点/拠点VPNルータ）
+- Amazon Linux 2023 + `t4g.nano` + `gp3 10GB` のEC2（サービス/拠点/中継プロキシ/拠点VPNルータ）
 - サービスVPC内のInternal NLB（TCP/80）
 - PrivateLink Endpoint Service
 - 中継VPC内のInterface VPC Endpoint（固定IP指定）
+- TGW（service/relay_a/relay_b接続）
 - 中継VPCごとのVGW
 - 拠点ごとのCGW（拠点VPNルータEC2のEIPを利用）
 - 拠点ごとのSite-to-Site VPN接続
-- EC2 Instance Connect Endpoint（サービスVPC/拠点VPC）
+- Route53 Resolver Inbound Endpoint（中継VPC）
+- Route53 Private Hosted Zone（`svc.vpn.bmuscle.net` を中継VPCごとに作成）
+- EC2 Instance Connect Endpoint（サービスVPC/中継VPC/拠点VPC）
 
 ## 手動作業
 
@@ -38,11 +44,15 @@
 
 ## Route53委任 + Inbound Resolver設定
 
-この構成では `private_dns_name`（例: `vpn.bmuscle.net`）を使ってPrivateLinkへ接続します。
+この構成では以下の2種類の名前解決を併用します。
+
+- `vpn.bmuscle.net`: PrivateLink（Endpoint Service private DNS）
+- `svc.vpn.bmuscle.net`: TGW + 中継Nginxプロキシ経路（拠点 -> サービス）
 
 - 親ゾーン: `bmuscle.net`
 - 子ゾーン: `vpn.bmuscle.net`（Terraformで作成し、親ゾーンにNS委任）
 - 中継VPC: Route53 Resolver Inbound Endpointを作成
+- 中継VPC: `svc.vpn.bmuscle.net` のPrivate Hosted Zoneを中継ごとに作成
 
 適用後に以下を確認します。
 
@@ -50,6 +60,8 @@
 terraform output delegated_public_zone_name_servers
 terraform output private_dns_name_verification_record
 terraform output relay_inbound_resolver_ips
+terraform output relay_proxy_private_ips
+terraform output site_to_service_domain
 ```
 
 補足:
@@ -99,13 +111,18 @@ EOF
 確認:
 
 ```bash
+# TGW + 中継Proxy向け名前解決
+nslookup svc.vpn.bmuscle.net
+
+# PrivateLink向け名前解決
 nslookup vpn.bmuscle.net
-curl -I http://vpn.bmuscle.net
 ```
 
-## Nginx設定手順（WebサーバーEC2へSSH接続後）
+## Nginx設定手順（EC2へSSH接続後）
 
-この手順はサービスVPCのWeb EC2、拠点VPCのWeb EC2のどちらでも同じです。
+### 1. サービスWeb（Nginx）
+
+サービスVPCのWeb EC2で実施します。
 
 1. Nginxをインストール
 
@@ -128,19 +145,132 @@ curl -I http://127.0.0.1
 
 `HTTP/1.1 200 OK` が返れば、デフォルトページ配信まで完了です。
 
-4. リモート疎通確認
+### 2. 拠点Web（パッケージ導入なしで80番応答）
+
+拠点VPCのWeb EC2（`site_a`/`site_b`）で、標準搭載のPythonのみを使って80番応答を起動します。
+
+1. コンテンツを配置
 
 ```bash
-# site_a拠点から service への確認
-curl -I http://10.0.10.4
+sudo mkdir -p /opt/site-http
+cat <<'EOF' | sudo tee /opt/site-http/index.html >/dev/null
+<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>site web</title></head>
+  <body>
+    <h1>site web</h1>
+    <p>served by python http.server on port 80</p>
+  </body>
+</html>
+EOF
+```
 
-# site_b拠点から service への確認
-curl -I http://10.0.10.36
+2. systemdサービスを作成して起動
+
+```bash
+cat <<'EOF' | sudo tee /etc/systemd/system/site-http.service >/dev/null
+[Unit]
+Description=Simple HTTP server for connectivity checks
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 -m http.server 80 --bind 0.0.0.0 --directory /opt/site-http
+Restart=always
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now site-http
+sudo systemctl status site-http --no-pager
+curl -I http://127.0.0.1
+```
+
+### 3. 中継Proxy（relay_a / relay_b）
+
+relay_aとrelay_bのプロキシEC2で実施します。
+（Terraform側で中継VPCはIGW配下のPublic Subnet化し、relay proxyにPublic IPを付与しています）
+
+1. Nginxをインストール
+
+```bash
+sudo dnf install -y nginx
+```
+
+2. プロキシ設定を作成
+
+```bash
+sudo tee /etc/nginx/conf.d/relay-proxy.conf >/dev/null <<'EOF'
+server {
+  listen 80;
+  server_name svc.vpn.bmuscle.net;
+
+  location / {
+    # 拠点 -> 中継Proxy -> サービス の経路
+    proxy_pass http://<SERVICE_NLB_DNS_NAME>;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}
+
+server {
+  listen 80 default_server;
+  server_name _;
+
+  location / {
+    # サービス -> 中継Proxy固定IP -> 拠点Web の経路
+    proxy_pass http://192.168.10.10;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}
+EOF
+```
+
+`<SERVICE_NLB_DNS_NAME>` は `terraform output service_nlb_dns_name` の値に置き換えてください。
+
+3. Nginxを起動し設定反映
+
+```bash
+sudo nginx -t
+sudo systemctl enable --now nginx
+sudo systemctl restart nginx
+```
+
+### 4. リモート疎通確認
+
+```bash
+# 拠点 -> サービス（ドメインHTTP）
+curl -I http://svc.vpn.bmuscle.net
+
+# サービス -> 拠点（固定IP HTTP。中継Proxy宛て）
+curl -I http://10.0.10.7
+curl -I http://10.0.10.39
 ```
 
 補足:
 - サービスWeb EC2はインターネットからの直接到達を許可していません。
-- 拠点Web EC2のHTTPは同一拠点CIDR（`192.168.10.0/24`）からのみ許可しています。
+- 拠点Web EC2は同一拠点CIDRに加えて、対応する中継CIDRからのHTTPを許可しています。
+- 中継Proxy EC2はdnf導入のためPublic IPを持ちますが、受信はsite/service CIDRのみ許可しています。
+- 中継間（relay_a <-> relay_b）はTGWルートテーブル分離により通信しません。
+
+## 拠点間分離の検証
+
+拠点A/Bは同一CIDRのため、対向拠点へ直接ルーティングできません。中継もTGWで分離しているため、以下の疎通は失敗する想定です。
+
+```bash
+# site_a から relay_b の中継Proxyへ（失敗すること）
+curl --connect-timeout 3 http://10.0.10.39
+
+# site_b から relay_a の中継Proxyへ（失敗すること）
+curl --connect-timeout 3 http://10.0.10.7
+```
 
 ## Libreswan設定手順（拠点VPNルータへSSH接続後）
 
@@ -253,11 +383,11 @@ sudo ipsec trafficstatus
 9. 疎通確認（拠点Webサーバー等から実施）
 
 ```bash
-# site_a側の確認
-curl -I http://10.0.10.4
+# site_a/site_b側の確認（TGW + 中継Proxy経路）
+curl -I http://svc.vpn.bmuscle.net
 
-# site_b側の確認
-curl -I http://10.0.10.36
+# PrivateLink併用確認（必要に応じて）
+curl -I http://vpn.bmuscle.net
 ```
 
 補足:
@@ -295,7 +425,18 @@ No modules.
 |------|------|
 | [aws_customer_gateway.site](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/customer_gateway) | resource |
 | [aws_ec2_instance_connect_endpoint.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_instance_connect_endpoint) | resource |
+| [aws_ec2_transit_gateway.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway) | resource |
+| [aws_ec2_transit_gateway_route.relay_a_to_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route) | resource |
+| [aws_ec2_transit_gateway_route.relay_b_to_service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route) | resource |
+| [aws_ec2_transit_gateway_route.service_to_relay_a](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route) | resource |
+| [aws_ec2_transit_gateway_route.service_to_relay_b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route) | resource |
+| [aws_ec2_transit_gateway_route_table.relay_a](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table) | resource |
+| [aws_ec2_transit_gateway_route_table.relay_b](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table) | resource |
+| [aws_ec2_transit_gateway_route_table.service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table) | resource |
+| [aws_ec2_transit_gateway_route_table_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_association) | resource |
+| [aws_ec2_transit_gateway_vpc_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_vpc_attachment) | resource |
 | [aws_eip.site_vpn_router](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_instance.relay_proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_instance.service_web](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_instance.site_vpn_router](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_instance.site_web](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
@@ -305,16 +446,21 @@ No modules.
 | [aws_lb_target_group.service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group) | resource |
 | [aws_lb_target_group_attachment.service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_target_group_attachment) | resource |
 | [aws_route.default_to_igw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.relay_to_service_via_tgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.relay_to_site](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
+| [aws_route.service_to_relay_via_tgw](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route.site_to_relay](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route) | resource |
 | [aws_route53_record.delegation_ns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.endpoint_service_private_dns_verification](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.relay_service_domain_a](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_resolver_endpoint.relay_inbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_resolver_endpoint) | resource |
 | [aws_route53_zone.delegated_private_dns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
+| [aws_route53_zone.relay_service_domain](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) | resource |
 | [aws_route_table.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
 | [aws_route_table_association.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
 | [aws_security_group.eic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.relay_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group.relay_proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.relay_resolver_inbound](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.service_web](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.site_vpn_router](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
@@ -346,11 +492,13 @@ No modules.
 | <a name="input_parent_public_zone_name"></a> [parent\_public\_zone\_name](#input\_parent\_public\_zone\_name) | parent public hosted zone name used for NS delegation | `string` | n/a | yes |
 | <a name="input_private_dns_name"></a> [private\_dns\_name](#input\_private\_dns\_name) | private DNS name for endpoint service | `string` | n/a | yes |
 | <a name="input_relay_inbound_resolver_ips"></a> [relay\_inbound\_resolver\_ips](#input\_relay\_inbound\_resolver\_ips) | fixed IP addresses for inbound resolver endpoints in relay VPCs | `map(list(string))` | <pre>{<br>  "relay_a": [<br>    "10.0.10.5",<br>    "10.0.10.6"<br>  ],<br>  "relay_b": [<br>    "10.0.10.37",<br>    "10.0.10.38"<br>  ]<br>}</pre> | no |
+| <a name="input_relay_proxy_private_ips"></a> [relay\_proxy\_private\_ips](#input\_relay\_proxy\_private\_ips) | fixed private IP addresses for relay proxy EC2 instances | `map(string)` | <pre>{<br>  "relay_a": "10.0.10.7",<br>  "relay_b": "10.0.10.39"<br>}</pre> | no |
 | <a name="input_relay_vgw_asns"></a> [relay\_vgw\_asns](#input\_relay\_vgw\_asns) | amazon side ASN for relay VGWs | `map(number)` | <pre>{<br>  "relay_a": 64512,<br>  "relay_b": 64513<br>}</pre> | no |
 | <a name="input_relay_vpc_cidrs"></a> [relay\_vpc\_cidrs](#input\_relay\_vpc\_cidrs) | relay vpc cidr blocks | `map(string)` | <pre>{<br>  "relay_a": "10.0.10.0/27",<br>  "relay_b": "10.0.10.32/27"<br>}</pre> | no |
 | <a name="input_root_volume_size_gb"></a> [root\_volume\_size\_gb](#input\_root\_volume\_size\_gb) | root ebs volume size in GB | `number` | `10` | no |
 | <a name="input_service_vpc_cidr"></a> [service\_vpc\_cidr](#input\_service\_vpc\_cidr) | service vpc cidr block | `string` | `"10.0.0.0/24"` | no |
 | <a name="input_site_customer_gateway_bgp_asns"></a> [site\_customer\_gateway\_bgp\_asns](#input\_site\_customer\_gateway\_bgp\_asns) | BGP ASNs for site customer gateways | `map(number)` | <pre>{<br>  "site_a": 65010,<br>  "site_b": 65020<br>}</pre> | no |
+| <a name="input_site_to_service_domain"></a> [site\_to\_service\_domain](#input\_site\_to\_service\_domain) | domain name used by site side HTTP access to service via relay proxy | `string` | `"svc.vpn.bmuscle.net"` | no |
 | <a name="input_site_vpc_cidr"></a> [site\_vpc\_cidr](#input\_site\_vpc\_cidr) | site vpc cidr block | `string` | `"192.168.10.0/24"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | default tags | `map(string)` | `{}` | no |
 
@@ -363,12 +511,17 @@ No modules.
 | <a name="output_private_dns_name_verification_record"></a> [private\_dns\_name\_verification\_record](#output\_private\_dns\_name\_verification\_record) | TXT record information for endpoint service private DNS verification |
 | <a name="output_relay_inbound_resolver_endpoint_ids"></a> [relay\_inbound\_resolver\_endpoint\_ids](#output\_relay\_inbound\_resolver\_endpoint\_ids) | inbound resolver endpoint ids in relay VPCs |
 | <a name="output_relay_inbound_resolver_ips"></a> [relay\_inbound\_resolver\_ips](#output\_relay\_inbound\_resolver\_ips) | fixed inbound resolver IPs in relay VPCs |
+| <a name="output_relay_proxy_instance_ids"></a> [relay\_proxy\_instance\_ids](#output\_relay\_proxy\_instance\_ids) | relay proxy instance ids |
+| <a name="output_relay_proxy_private_ips"></a> [relay\_proxy\_private\_ips](#output\_relay\_proxy\_private\_ips) | fixed private IP addresses for relay proxy instances |
 | <a name="output_relay_vpc_endpoint_fixed_ips"></a> [relay\_vpc\_endpoint\_fixed\_ips](#output\_relay\_vpc\_endpoint\_fixed\_ips) | fixed private IP addresses for relay interface endpoints |
 | <a name="output_relay_vpc_endpoint_ids"></a> [relay\_vpc\_endpoint\_ids](#output\_relay\_vpc\_endpoint\_ids) | interface endpoint ids in relay VPCs |
 | <a name="output_service_instance_id"></a> [service\_instance\_id](#output\_service\_instance\_id) | service web instance id |
 | <a name="output_service_nlb_dns_name"></a> [service\_nlb\_dns\_name](#output\_service\_nlb\_dns\_name) | DNS name of service NLB |
+| <a name="output_site_to_service_domain"></a> [site\_to\_service\_domain](#output\_site\_to\_service\_domain) | domain name used by site web EC2 to access service through relay proxy |
 | <a name="output_site_vpn_router_instance_ids"></a> [site\_vpn\_router\_instance\_ids](#output\_site\_vpn\_router\_instance\_ids) | site vpn router instance ids |
 | <a name="output_site_vpn_router_public_ips"></a> [site\_vpn\_router\_public\_ips](#output\_site\_vpn\_router\_public\_ips) | public ips used by customer gateways |
 | <a name="output_site_web_instance_ids"></a> [site\_web\_instance\_ids](#output\_site\_web\_instance\_ids) | site web instance ids |
+| <a name="output_transit_gateway_id"></a> [transit\_gateway\_id](#output\_transit\_gateway\_id) | transit gateway id for service-relay connectivity |
+| <a name="output_transit_gateway_route_table_ids"></a> [transit\_gateway\_route\_table\_ids](#output\_transit\_gateway\_route\_table\_ids) | transit gateway route table ids |
 | <a name="output_vpn_connection_ids"></a> [vpn\_connection\_ids](#output\_vpn\_connection\_ids) | site to relay vpn connection ids |
 <!-- END_TF_DOCS -->

--- a/compute.tf
+++ b/compute.tf
@@ -45,9 +45,11 @@ resource "aws_instance" "service_web" {
 resource "aws_instance" "site_web" {
   for_each = local.site_keys
 
-  ami                         = data.aws_ami.amazon_linux_arm64.id
-  instance_type               = var.instance_type
-  subnet_id                   = aws_subnet.main[each.key].id
+  ami           = data.aws_ami.amazon_linux_arm64.id
+  instance_type = var.instance_type
+  subnet_id     = aws_subnet.main[each.key].id
+  # 中継プロキシからの逆方向通信先を固定化するため、拠点WebのIPを固定する。
+  private_ip                  = cidrhost(var.site_vpc_cidr, 10)
   vpc_security_group_ids      = [aws_security_group.site_web[each.key].id]
   associate_public_ip_address = true
 
@@ -65,6 +67,35 @@ resource "aws_instance" "site_web" {
 
   tags = merge(local.tags, {
     Name = "${var.name}-${each.key}-web"
+  })
+}
+
+resource "aws_instance" "relay_proxy" {
+  for_each = local.relay_keys
+
+  ami                    = data.aws_ami.amazon_linux_arm64.id
+  instance_type          = var.instance_type
+  subnet_id              = aws_subnet.main[each.key].id
+  private_ip             = var.relay_proxy_private_ips[each.key]
+  vpc_security_group_ids = [aws_security_group.relay_proxy[each.key].id]
+  # パッケージ導入のため外向きインターネットを使えるようにする。
+  # 受信はSGで site/service CIDR のみ許可し、インターネット公開はしない。
+  associate_public_ip_address = true
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
+  root_block_device {
+    volume_size           = var.root_volume_size_gb
+    volume_type           = "gp3"
+    encrypted             = true
+    delete_on_termination = true
+  }
+
+  tags = merge(local.tags, {
+    Name = "${var.name}-${each.key}-proxy"
   })
 }
 
@@ -108,7 +139,7 @@ resource "aws_eip" "site_vpn_router" {
 }
 
 resource "aws_ec2_instance_connect_endpoint" "this" {
-  for_each = toset(["service", "site_a", "site_b"])
+  for_each = local.eic_keys
 
   subnet_id          = aws_subnet.main[each.key].id
   security_group_ids = [aws_security_group.eic[each.key].id]

--- a/dns-private.tf
+++ b/dns-private.tf
@@ -1,0 +1,26 @@
+resource "aws_route53_zone" "relay_service_domain" {
+  for_each = local.relay_keys
+
+  # 同一FQDNをrelayごとに別ゾーンとして持ち、拠点ごとの問い合わせ先で解決先を分ける。
+  name = trimsuffix(var.site_to_service_domain, ".")
+
+  vpc {
+    vpc_id = aws_vpc.this[each.key].id
+  }
+
+  tags = merge(local.tags, {
+    Name = "${var.name}-${each.key}-private-zone"
+  })
+}
+
+resource "aws_route53_record" "relay_service_domain_a" {
+  for_each = local.relay_keys
+
+  # site_aはrelay_aのInbound Resolver、site_bはrelay_bのInbound Resolverを使うため、
+  # 同じFQDNでも問い合わせ元の経路で返却IPが変わる（split-horizon）。
+  zone_id = aws_route53_zone.relay_service_domain[each.key].zone_id
+  name    = trimsuffix(var.site_to_service_domain, ".")
+  type    = "A"
+  ttl     = 60
+  records = [var.relay_proxy_private_ips[each.key]]
+}

--- a/locals.tf
+++ b/locals.tf
@@ -8,14 +8,16 @@ locals {
       enable_dns_hostnames = true
     }
     relay_a = {
-      cidr                 = var.relay_vpc_cidrs["relay_a"]
-      igw                  = false
+      cidr = var.relay_vpc_cidrs["relay_a"]
+      # 中継Proxyでdnf導入を可能にするため、IGW配下のPublic Subnetとして扱う。
+      igw                  = true
       enable_dns_support   = true
       enable_dns_hostnames = true
     }
     relay_b = {
-      cidr                 = var.relay_vpc_cidrs["relay_b"]
-      igw                  = false
+      cidr = var.relay_vpc_cidrs["relay_b"]
+      # 中継Proxyでdnf導入を可能にするため、IGW配下のPublic Subnetとして扱う。
+      igw                  = true
       enable_dns_support   = true
       enable_dns_hostnames = true
     }
@@ -37,6 +39,8 @@ locals {
 
   relay_keys = toset(["relay_a", "relay_b"])
   site_keys  = toset(["site_a", "site_b"])
+  eic_keys   = setunion(toset(["service"]), local.relay_keys, local.site_keys)
+  tgw_keys   = setunion(toset(["service"]), local.relay_keys)
 
   # 拠点A/Bと中継A/Bを1:1で固定マッピングする。
   site_to_relay = {

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,16 @@ output "site_web_instance_ids" {
   value       = { for key, value in aws_instance.site_web : key => value.id }
 }
 
+output "relay_proxy_instance_ids" {
+  description = "relay proxy instance ids"
+  value       = { for key, value in aws_instance.relay_proxy : key => value.id }
+}
+
+output "relay_proxy_private_ips" {
+  description = "fixed private IP addresses for relay proxy instances"
+  value       = var.relay_proxy_private_ips
+}
+
 output "site_vpn_router_instance_ids" {
   description = "site vpn router instance ids"
   value       = { for key, value in aws_instance.site_vpn_router : key => value.id }
@@ -21,6 +31,20 @@ output "site_vpn_router_instance_ids" {
 output "site_vpn_router_public_ips" {
   description = "public ips used by customer gateways"
   value       = { for key, value in aws_eip.site_vpn_router : key => value.public_ip }
+}
+
+output "transit_gateway_id" {
+  description = "transit gateway id for service-relay connectivity"
+  value       = aws_ec2_transit_gateway.main.id
+}
+
+output "transit_gateway_route_table_ids" {
+  description = "transit gateway route table ids"
+  value = {
+    service = aws_ec2_transit_gateway_route_table.service.id
+    relay_a = aws_ec2_transit_gateway_route_table.relay_a.id
+    relay_b = aws_ec2_transit_gateway_route_table.relay_b.id
+  }
 }
 
 output "relay_vpc_endpoint_ids" {
@@ -51,6 +75,11 @@ output "relay_inbound_resolver_endpoint_ids" {
 output "relay_inbound_resolver_ips" {
   description = "fixed inbound resolver IPs in relay VPCs"
   value       = var.relay_inbound_resolver_ips
+}
+
+output "site_to_service_domain" {
+  description = "domain name used by site web EC2 to access service through relay proxy"
+  value       = var.site_to_service_domain
 }
 
 output "delegated_public_zone_name_servers" {

--- a/security.tf
+++ b/security.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "eic" {
-  for_each = toset(["service", "site_a", "site_b"])
+  for_each = local.eic_keys
 
   name        = "${var.name}-${each.key}-eic-sg"
   description = "security group for EC2 Instance Connect Endpoint"
@@ -72,11 +72,14 @@ resource "aws_security_group" "site_web" {
   vpc_id      = aws_vpc.this[each.key].id
 
   ingress {
-    description = "allow HTTP from same site network"
+    description = "allow HTTP from same site network and mapped relay network"
     from_port   = 80
     to_port     = 80
     protocol    = "tcp"
-    cidr_blocks = [var.site_vpc_cidr]
+    cidr_blocks = [
+      var.site_vpc_cidr,
+      var.relay_vpc_cidrs[local.site_to_relay[each.key]],
+    ]
   }
 
   ingress {
@@ -96,6 +99,51 @@ resource "aws_security_group" "site_web" {
 
   tags = merge(local.tags, {
     Name = "${var.name}-${each.key}-web-sg"
+  })
+}
+
+resource "aws_security_group" "relay_proxy" {
+  for_each = local.relay_keys
+
+  name        = "${var.name}-${each.key}-proxy-sg"
+  description = "security group for relay proxy EC2"
+  vpc_id      = aws_vpc.this[each.key].id
+
+  ingress {
+    # 拠点 -> サービス方向: 拠点Webから中継プロキシへHTTPを受ける。
+    description = "allow HTTP from site network"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [var.site_vpc_cidr]
+  }
+
+  ingress {
+    # サービス -> 拠点方向: サービスWebから中継プロキシ固定IPへHTTPを受ける。
+    description = "allow HTTP from service network"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = [var.service_vpc_cidr]
+  }
+
+  ingress {
+    description     = "allow SSH via EIC endpoint"
+    from_port       = 22
+    to_port         = 22
+    protocol        = "tcp"
+    security_groups = [aws_security_group.eic[each.key].id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(local.tags, {
+    Name = "${var.name}-${each.key}-proxy-sg"
   })
 }
 

--- a/tgw.tf
+++ b/tgw.tf
@@ -1,0 +1,109 @@
+resource "aws_ec2_transit_gateway" "main" {
+  description                     = "transit gateway for service and relay connectivity"
+  default_route_table_association = "disable"
+  default_route_table_propagation = "disable"
+  dns_support                     = "enable"
+  vpn_ecmp_support                = "disable"
+
+  tags = merge(local.tags, {
+    Name = "${var.name}-tgw"
+  })
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
+  for_each = local.tgw_keys
+
+  subnet_ids         = [aws_subnet.main[each.key].id]
+  transit_gateway_id = aws_ec2_transit_gateway.main.id
+  vpc_id             = aws_vpc.this[each.key].id
+  dns_support        = "enable"
+  ipv6_support       = "disable"
+
+  tags = merge(local.tags, {
+    Name = "${var.name}-${each.key}-tgw-attachment"
+  })
+}
+
+resource "aws_ec2_transit_gateway_route_table" "service" {
+  transit_gateway_id = aws_ec2_transit_gateway.main.id
+
+  tags = merge(local.tags, {
+    Name = "${var.name}-service-tgw-rt"
+  })
+}
+
+resource "aws_ec2_transit_gateway_route_table" "relay_a" {
+  transit_gateway_id = aws_ec2_transit_gateway.main.id
+
+  tags = merge(local.tags, {
+    Name = "${var.name}-relay-a-tgw-rt"
+  })
+}
+
+resource "aws_ec2_transit_gateway_route_table" "relay_b" {
+  transit_gateway_id = aws_ec2_transit_gateway.main.id
+
+  tags = merge(local.tags, {
+    Name = "${var.name}-relay-b-tgw-rt"
+  })
+}
+
+locals {
+  tgw_route_table_ids = {
+    service = aws_ec2_transit_gateway_route_table.service.id
+    relay_a = aws_ec2_transit_gateway_route_table.relay_a.id
+    relay_b = aws_ec2_transit_gateway_route_table.relay_b.id
+  }
+}
+
+resource "aws_ec2_transit_gateway_route_table_association" "this" {
+  for_each = local.tgw_keys
+
+  # 各VPC attachmentを専用RTへ関連付け、伝播に頼らず明示ルーティングで分離する。
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this[each.key].id
+  transit_gateway_route_table_id = local.tgw_route_table_ids[each.key]
+}
+
+resource "aws_ec2_transit_gateway_route" "service_to_relay_a" {
+  # serviceはrelay_aへ到達可能。
+  destination_cidr_block         = var.relay_vpc_cidrs["relay_a"]
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this["relay_a"].id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.service.id
+}
+
+resource "aws_ec2_transit_gateway_route" "service_to_relay_b" {
+  # serviceはrelay_bへ到達可能。
+  destination_cidr_block         = var.relay_vpc_cidrs["relay_b"]
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this["relay_b"].id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.service.id
+}
+
+resource "aws_ec2_transit_gateway_route" "relay_a_to_service" {
+  # relay_aはserviceのみに到達可能。relay_b宛ては作らない。
+  destination_cidr_block         = var.service_vpc_cidr
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this["service"].id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.relay_a.id
+}
+
+resource "aws_ec2_transit_gateway_route" "relay_b_to_service" {
+  # relay_bはserviceのみに到達可能。relay_a宛ては作らない。
+  destination_cidr_block         = var.service_vpc_cidr
+  transit_gateway_attachment_id  = aws_ec2_transit_gateway_vpc_attachment.this["service"].id
+  transit_gateway_route_table_id = aws_ec2_transit_gateway_route_table.relay_b.id
+}
+
+resource "aws_route" "service_to_relay_via_tgw" {
+  for_each = local.relay_keys
+
+  route_table_id         = aws_route_table.main["service"].id
+  destination_cidr_block = var.relay_vpc_cidrs[each.key]
+  transit_gateway_id     = aws_ec2_transit_gateway.main.id
+}
+
+resource "aws_route" "relay_to_service_via_tgw" {
+  for_each = local.relay_keys
+
+  route_table_id         = aws_route_table.main[each.key].id
+  destination_cidr_block = var.service_vpc_cidr
+  transit_gateway_id     = aws_ec2_transit_gateway.main.id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -73,6 +73,23 @@ variable "endpoint_private_ips" {
   }
 }
 
+variable "relay_proxy_private_ips" {
+  description = "fixed private IP addresses for relay proxy EC2 instances"
+  type        = map(string)
+  default = {
+    relay_a = "10.0.10.7"
+    relay_b = "10.0.10.39"
+  }
+
+  validation {
+    condition = alltrue([
+      contains(keys(var.relay_proxy_private_ips), "relay_a"),
+      contains(keys(var.relay_proxy_private_ips), "relay_b"),
+    ])
+    error_message = "relay_proxy_private_ips must include relay_a and relay_b keys."
+  }
+}
+
 variable "relay_vgw_asns" {
   description = "amazon side ASN for relay VGWs"
   type        = map(number)
@@ -98,6 +115,17 @@ variable "private_dns_name" {
   validation {
     condition     = can(regex("^[A-Za-z0-9.-]+$", var.private_dns_name))
     error_message = "private_dns_name must be a valid DNS name."
+  }
+}
+
+variable "site_to_service_domain" {
+  description = "domain name used by site side HTTP access to service via relay proxy"
+  type        = string
+  default     = "svc.vpn.bmuscle.net"
+
+  validation {
+    condition     = can(regex("^[A-Za-z0-9.-]+$", var.site_to_service_domain))
+    error_message = "site_to_service_domain must be a valid DNS name."
   }
 }
 

--- a/vars/dev.tfvars
+++ b/vars/dev.tfvars
@@ -2,5 +2,10 @@ aws_account_id          = "314211214994"
 name                    = "vpn-sandbox-dev"
 env                     = "dev"
 private_dns_name        = "vpn.bmuscle.net"
+site_to_service_domain  = "svc.vpn.bmuscle.net"
 parent_public_zone_name = "bmuscle.net"
 enable_vpce_private_dns = true
+relay_proxy_private_ips = {
+  relay_a = "10.0.10.7"
+  relay_b = "10.0.10.39"
+}


### PR DESCRIPTION
問題なく動作確認完了。

拠点ごとの名前解決出し分けは、Rotue53のPrivate Host Zoneを利用する。
VPCごとに紐づけることが可能であるため、拠点ごとに名前解決の先を変更することができる。
Terraformを利用しているため、自動的に設定可能。